### PR TITLE
[DBRE-2974][rabbitmq] use the  dedicated nodepool by default

### DIFF
--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -576,12 +576,17 @@ affinity: |
 ## @param nodeSelector Node labels for pod assignment. Evaluated as a template
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
-nodeSelector: {}
+nodeSelector:
+  dedicated: "datastores"
 
 ## @param tolerations Tolerations for pod assignment. Evaluated as a template
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
-tolerations: []
+tolerations:
+- key: dedicated
+  operator: Equal
+  value: "datastores"
+  effect: NoSchedule
 
 ## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods


### PR DESCRIPTION
Use the `datastores` dedicated nodepool by default, cf: https://blablacar.atlassian.net/wiki/spaces/ARCH/pages/219062198/Databases+in+GCP#2021-10-Dedicated-K8S-nodepool-for-datastores
