### PR TITLE
[rabbitmq] secu+bump: switch to version 3.9.29 with own registry (DBRE-3303)

### DIFF
--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -28,9 +28,9 @@ global:
 ## @param image.debug Set to true if you would like to see extra information on logs
 ##
 image:
-  registry: docker.io
-  repository: bitnami/rabbitmq
-  tag: 3.9.18-debian-10-r0
+  registry: eu.gcr.io
+  repository: bbc-registry/rabbitmq
+  tag: 3.9.29
   ## set to true if you would like to see extra information on logs
   ## It turns BASH and/or NAMI debugging in the image
   ##


### PR DESCRIPTION

- [rabbitmq] secu+bump: switch to version 3.9.29, from self-owned registry
