### PR TITLE
Rebase from upstream (for rabbitmq 3.10)

### DIFF
--- a/bitnami/rabbitmq/Chart.yaml
+++ b/bitnami/rabbitmq/Chart.yaml
@@ -1,7 +1,7 @@
 annotations:
   category: Infrastructure
 apiVersion: v2
-appVersion: 3.10.8
+appVersion: 3.10.20
 dependencies:
   - name: common
     repository: https://charts.bitnami.com/bitnami

--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -279,7 +279,8 @@ spec:
               command:
                 - /bin/bash
                 - -ec
-                - rabbitmq-diagnostics -q ping
+                # about RABBITMQ_CTL_ERL_ARGS: https://github.com/bitnami/charts/issues/11116
+                - RABBITMQ_CTL_ERL_ARGS="+S 1:1" rabbitmq-diagnostics -q ping
           {{- end }}
           {{- if .Values.customReadinessProbe }}
           readinessProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customReadinessProbe "context" $) | nindent 12 }}
@@ -289,7 +290,8 @@ spec:
               command:
                 - /bin/bash
                 - -ec
-                - rabbitmq-diagnostics -q check_running && rabbitmq-diagnostics -q check_local_alarms
+                # about RABBITMQ_CTL_ERL_ARGS: https://github.com/bitnami/charts/issues/11116
+                - RABBITMQ_CTL_ERL_ARGS="+S 1:1" rabbitmq-diagnostics -q check_running && RABBITMQ_CTL_ERL_ARGS="+S 1:1" rabbitmq-diagnostics -q check_local_alarms
           {{- end }}
           {{- if .Values.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -15,7 +15,7 @@ global:
   ##   - myRegistryKeySecretName
   ##
   imagePullSecrets: []
-  storageClass: ""
+  storageClass: pd-balanced-retain
 
 ## @section RabbitMQ Image parameters
 ## Bitnami RabbitMQ image version

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -29,8 +29,8 @@ global:
 ## @param image.debug Set to true if you would like to see extra information on logs
 ##
 image:
-  registry: docker.io
-  repository: bitnami/rabbitmq
+  registry: eu.gcr.io
+  repository: bbc-registry/rabbitmq
   tag: 3.10.8-debian-11-r4
   digest: ""
   ## set to true if you would like to see extra information on logs
@@ -1343,8 +1343,8 @@ volumePermissions:
   ## @param volumePermissions.image.pullSecrets Specify docker-registry secret names as an array
   ##
   image:
-    registry: docker.io
-    repository: bitnami/bitnami-shell
+    registry: eu.gcr.io
+    repository: bbc-registry/bitnami-shell
     tag: 11-debian-11-r38
     digest: ""
     ## Specify a imagePullPolicy

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -675,11 +675,18 @@ affinity: |
 ## @param nodeSelector Node labels for pod assignment. Evaluated as a template
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
-nodeSelector: {}
+nodeSelector:
+  dedicated: "datastores"
+
 ## @param tolerations Tolerations for pod assignment. Evaluated as a template
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
 ##
-tolerations: []
+tolerations:
+- key: dedicated
+  operator: Equal
+  value: "datastores"
+  effect: NoSchedule
+
 ## @param topologySpreadConstraints Topology Spread Constraints for pod assignment spread across your cluster among failure-domains. Evaluated as a template
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#spread-constraints-for-pods
 ##

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -31,7 +31,7 @@ global:
 image:
   registry: eu.gcr.io
   repository: bbc-registry/rabbitmq
-  tag: 3.10.8-debian-11-r4
+  tag: 3.10.20
   digest: ""
   ## set to true if you would like to see extra information on logs
   ## It turns BASH and/or NAMI debugging in the image

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -437,6 +437,36 @@ advancedConfiguration: |-
       ]}]
   }].
 
+datadog:
+  enabled: true
+  #max_detailed_queues: 200
+  annotations:
+    ad.datadoghq.com/rabbitmq.check_names: '["rabbitmq"]'
+    ad.datadoghq.com/rabbitmq.init_configs: '[{}]'
+    ad.datadoghq.com/rabbitmq.instances: >-
+      [{
+       {{- if .Values.datadog.max_detailed_queues }}
+        "max_detailed_queues": {{ .Values.datadog.max_detailed_queues | quote }},
+        {{- end }}
+        "rabbitmq_api_url":"http://%%host%%:15672/api/",
+        "username":"datadog",
+        "password":"%%env_RABBITMQ_DATADOG_PASSWORD%%"
+      }]
+    ad.datadoghq.com/rabbitmq.logs: >-
+      [{
+        "source": "rabbitmq",
+        "service": "{{ .Release.Name }}",
+        "log_processing_rules": [
+          {
+            "type": "multi_line",
+            "name": "logs_starts_with_equal_sign",
+            "pattern" : "="
+          }
+        ]
+      }]
+  labels:
+    team: "team_dbre" # name of the team ex:team_dbre, used for cost control
+
 ## LDAP configuration
 ##
 ldap:
@@ -554,14 +584,26 @@ podManagementPolicy: OrderedReady
 ## @param podLabels RabbitMQ Pod labels. Evaluated as a template
 ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
-podLabels:
+podLabels: |
   app: "{{ .Release.Name }}"
   component: "database"
   sidecar.istio.io/inject: "false"
+  {{ if .Values.datadog.enabled -}}
+  tags.datadoghq.com/service: {{ .Release.Name | lower | quote }}
+  tags.datadoghq.com/version: {{ .Values.image.tag | quote }}
+  {{ with .Values.datadog.labels }}{{ toYaml . }}{{- end -}}
+  {{- end -}}
+
 ## @param podAnnotations RabbitMQ Pod annotations. Evaluated as a template
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
-podAnnotations: {}
+podAnnotations: |
+  {{- if .Values.datadog.enabled -}}
+  {{- range $k, $v := .Values.datadog.annotations }}
+  {{ $k }}: {{ tpl $v $ | quote }}
+  {{- end -}}
+  {{- end -}}
+
 ## @param updateStrategy.type Update strategy type for RabbitMQ statefulset
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
 ##
@@ -573,7 +615,13 @@ updateStrategy:
 ## @param statefulsetLabels RabbitMQ statefulset labels. Evaluated as a template
 ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
-statefulsetLabels: {}
+statefulsetLabels: |
+  {{- if .Values.datadog.enabled -}}
+  tags.datadoghq.com/service: {{ .Release.Name | lower | quote }}
+  tags.datadoghq.com/version: {{ .Values.image.tag | quote }}
+  {{ with .Values.datadog.labels }}{{ toYaml . }}{{- end -}}
+  {{- end -}}
+
 ## @param priorityClassName Name of the priority class to be used by RabbitMQ pods, priority class needs to be created beforehand
 ## Ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
 ##

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -200,7 +200,8 @@ memoryHighWatermark:
 
 ## @param plugins List of default plugins to enable (should only be altered to remove defaults; for additional plugins use `extraPlugins`)
 ##
-plugins: "rabbitmq_management rabbitmq_peer_discovery_k8s"
+plugins: "rabbitmq_management rabbitmq_peer_discovery_k8s rabbitmq_shovel rabbitmq_shovel_management"
+
 ## @param communityPlugins List of Community plugins (URLs) to be downloaded during container initialization
 ## Combine it with extraPlugins to also enable them.
 ##

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -186,7 +186,7 @@ onlineSchedulers: ""
 memoryHighWatermark:
   ## @param memoryHighWatermark.enabled Enable configuring Memory high watermark on RabbitMQ
   ##
-  enabled: false
+  enabled: true
   ## @param memoryHighWatermark.type Memory high watermark type. Either `absolute` or `relative`
   ##
   type: "relative"
@@ -196,7 +196,7 @@ memoryHighWatermark:
   ## Note: the memory relative limit is applied to the resource.limits.memory to calculate the memory threshold
   ## You can also use an absolute value, e.g.: 256MB
   ##
-  value: 0.4
+  value: 0.5
 
 ## @param plugins List of default plugins to enable (should only be altered to remove defaults; for additional plugins use `extraPlugins`)
 ##
@@ -208,7 +208,7 @@ communityPlugins: ""
 ## @param extraPlugins Extra plugins to enable (single string containing a space-separated list)
 ## Use this instead of `plugins` to add new plugins
 ##
-extraPlugins: "rabbitmq_auth_backend_ldap"
+extraPlugins: ""
 
 ## Clustering settings
 ##
@@ -415,7 +415,7 @@ configuration: |-
 extraConfiguration: |-
   #default_vhost = {{ .Release.Namespace }}-vhost
   #disk_free_limit.absolute = 50MB
-
+  disk_free_limit.absolute = 1GB
 ## @param advancedConfiguration Configuration file content: advanced configuration
 ## Use this as additional configuration in classic config format (Erlang term configuration format)
 ##
@@ -427,6 +427,14 @@ extraConfiguration: |-
 ##   ]}].
 ##
 advancedConfiguration: |-
+  [{rabbit, [
+    {log, [
+      {console, [{level, info}]},
+      {categories, [
+          {connection, [{level, warning}]}
+          ]}
+      ]}]
+  }].
 
 ## LDAP configuration
 ##
@@ -524,7 +532,8 @@ extraSecretsPrependReleaseName: false
 
 ## @param replicaCount Number of RabbitMQ replicas to deploy
 ##
-replicaCount: 1
+replicaCount: 3
+
 ## @param schedulerName Use an alternate scheduler, e.g. "stork".
 ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
 ##
@@ -544,7 +553,10 @@ podManagementPolicy: OrderedReady
 ## @param podLabels RabbitMQ Pod labels. Evaluated as a template
 ## Ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 ##
-podLabels: {}
+podLabels:
+  app: "{{ .Release.Name }}"
+  component: "database"
+  sidecar.istio.io/inject: "false"
 ## @param podAnnotations RabbitMQ Pod annotations. Evaluated as a template
 ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 ##
@@ -598,7 +610,19 @@ nodeAffinityPreset:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#affinity-and-anti-affinity
 ## Note: podAffinityPreset, podAntiAffinityPreset, and  nodeAffinityPreset will be ignored when it's set
 ##
-affinity: {}
+affinity: |
+  podAntiAffinity:
+    requiredDuringSchedulingIgnoredDuringExecution:
+      - labelSelector:
+          matchLabels: {{- include "common.labels.matchLabels" . | nindent 12 }}
+        topologyKey: kubernetes.io/hostname
+    preferredDuringSchedulingIgnoredDuringExecution:
+      - weight: 100
+        podAffinityTerm:
+          labelSelector:
+            matchLabels: {{- include "common.labels.matchLabels" . | nindent 14 }}
+          topologyKey: topology.kubernetes.io/zone
+
 ## @param nodeSelector Node labels for pod assignment. Evaluated as a template
 ## ref: https://kubernetes.io/docs/user-guide/node-selection/
 ##
@@ -651,12 +675,14 @@ resources:
   ##    cpu: 1000m
   ##    memory: 2Gi
   ##
-  limits: {}
+  limits:
   ## Examples:
   ## requests:
   ##    cpu: 1000m
   ##    memory: 2Gi
   ##
+# We need a default limit here, so that the Chart can work with highwatermark enabled (which is using limits.memory) by default, mainly for CI tests
+    memory: 1Gi
   requests: {}
 
 ## Configure RabbitMQ containers' extra options for liveness probe
@@ -748,13 +774,13 @@ sidecars: []
 pdb:
   ## @param pdb.create Enable/disable a Pod Disruption Budget creation
   ##
-  create: false
+  create: true
   ## @param pdb.minAvailable Minimum number/percentage of pods that should remain scheduled
   ##
-  minAvailable: 1
+  #minAvailable: 1
   ## @param pdb.maxUnavailable Maximum number/percentage of pods that may be made unavailable
   ##
-  maxUnavailable: ""
+  maxUnavailable: 1
 
 ## @section RBAC parameters
 ##
@@ -937,7 +963,10 @@ service:
   clusterIP: ""
   ## @param service.labels Service labels. Evaluated as a template
   ##
-  labels: {}
+  labels:
+    app: "{{ .Release.Name }}"
+    component: "database"
+
   ## @param service.annotations Service annotations. Evaluated as a template
   ## Example:
   ## annotations:
@@ -1249,7 +1278,7 @@ metrics:
 volumePermissions:
   ## @param volumePermissions.enabled Enable init container that changes the owner and group of the persistent volume(s) mountpoint to `runAsUser:fsGroup`
   ##
-  enabled: false
+  enabled: true
   ## @param volumePermissions.image.registry Init container volume-permissions image registry
   ## @param volumePermissions.image.repository Init container volume-permissions image repository
   ## @param volumePermissions.image.tag Init container volume-permissions image tag


### PR DESCRIPTION
Here is the branch that I rebased above `93b0f1a9c8` (the last commit with RabbitMQ 3.10, the version we want, so not the latest commit of master which is for RabbitMQ 3.11)

⚠️ This branch **MUST NOT** be merged, it's just for review (on github, and manually with git diff commands) ⚠️ 
The "merge" is replaced by a push force on the fork branch, cf [our fork-guide](https://blablacar.atlassian.net/wiki/spaces/ARCH/pages/2276491319/Bitnami+Helm+Charts+Fork#Realign-with-upstream-to-benefit-last-changes)

Changes versus our previous fork:
- **[removed]** the statefulsetAnnotations that were used for the version-tracker (which is decommissioned)
- **[changed]** the repository of bitnami-shell (no bitnami anymore, it's useless, cf: [PR](https://github.com/blablacar/dockerfiles/pull/1051))
- **[changed]** istio label/annotation, cf: DBRE-3455
- **[new]** set the number of erlang schedulers for probes (to avoid high CPU usage)