### PR TITLE
[rabbitmq] probes: ensure that timeout is applied

### DIFF
--- a/bitnami/rabbitmq/templates/statefulset.yaml
+++ b/bitnami/rabbitmq/templates/statefulset.yaml
@@ -294,7 +294,7 @@ spec:
                 #   cf: https://github.com/bitnami/charts/issues/11116
                 #   NB: the `--timeout` of rabbitmq-diagnostics doesn't solve this issue
                 #   Warning: this issue only starts a few hours/days after pod's creation, and is "random" (no known way to reproduce)
-                - /usr/bin/timeout {{ .Values.readinessProbe.timeoutSeconds }} rabbitmq-diagnostics -q check_running && /usr/bin/timeout {{ .Values.readinessProbe.timeoutSeconds }} rabbitmq-diagnostics -q check_local_alarms
+                - /usr/bin/timeout --kill-after=10 {{ .Values.readinessProbe.timeoutSeconds }} rabbitmq-diagnostics -q check_running && /usr/bin/timeout --kill-after=10 {{ .Values.readinessProbe.timeoutSeconds }} rabbitmq-diagnostics -q check_local_alarms
           {{- end }}
           {{- if .Values.customStartupProbe }}
           startupProbe: {{- include "common.tplvalues.render" (dict "value" .Values.customStartupProbe "context" $) | nindent 12 }}


### PR DESCRIPTION
The previous PR (https://github.com/blablacar/helm-charts-bitnami/pull/7) is not enough, the issue is still present, cf: this example:
```
I have no name!@rabbitmq-communication-1:/$ date; ps faux |cat
Fri 21 Apr 2023 04:06:26 PM UTC
USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
1001       19545  0.0  0.0   7172  3868 pts/0    Ss   16:06   0:00 bash
1001       19552  0.0  0.0   9740  3352 pts/0    R+   16:06   0:00  \_ ps faux
1001       19553  0.0  0.0   5512   572 pts/0    S+   16:06   0:00  \_ cat
1001           1  0.0  0.0   2492  1616 ?        Ss   14:55   0:00 /bin/sh /opt/bitnami/rabbitmq/sbin/rabbitmq-server
1001          62  2.0  0.1 2260348 148444 ?      Sl   14:55   1:25 /opt/bitnami/erlang/lib/erlang/erts-13.2/bin/beam.smp -W w -MBas ageffcbf -MHas ageffcbf -MBlmbcs 512 -MHlmbcs 512 -MMmcs 30 -P 1048576 -t 5000000 -stbt db -zdbbl 128000 -sbwt none -sbwtdcpu none -sbwtdio none -S 1:1 -B i -- -root /opt/bitnami/erlang/lib/erlang -bindir /opt/bitnami/erlang/lib/erlang/erts-13.2/bin -progname erl -- -home /opt/bitnami/rabbitmq/.rabbitmq -- -pa  -noshell -noinput -s rabbit boot -boot start_sasl -syslog logger [] -syslog syslog_error_logger false -kernel prevent_overlapping_partitions false
1001          68  0.0  0.0   2380  1288 ?        Ss   14:55   0:00  \_ erl_child_setup 1048576
1001         146  0.0  0.0   3724   900 ?        Ss   14:56   0:00      \_ /opt/bitnami/erlang/lib/erlang/erts-13.2/bin/inet_gethost 4
1001         147  0.0  0.0   3940  1824 ?        S    14:56   0:00      |   \_ /opt/bitnami/erlang/lib/erlang/erts-13.2/bin/inet_gethost 4
1001         150  0.0  0.0   2492   592 ?        Ss   14:56   0:00      \_ /bin/sh -s rabbit_disk_monitor
1001          95  0.0  0.0   4628  2108 ?        S    14:56   0:00 /opt/bitnami/erlang/lib/erlang/erts-13.2/bin/epmd -daemon
1001        9744  0.0  0.0   5564   628 ?        S    15:30   0:00 /usr/bin/timeout 20 rabbitmq-diagnostics -q check_running
1001        9745 99.3  0.0 2116920 57964 ?       Sl   15:30  35:14  \_ /opt/bitnami/erlang/lib/erlang/erts-13.2/bin/beam.smp -B -S 1:1 -- -root /opt/bitnami/erlang/lib/erlang -bindir /opt/bitnami/erlang/lib/erlang/erts-13.2/bin -progname erl -- -home /opt/bitnami/rabbitmq/.rabbitmq -- -boot start_clean -noshell -noinput -noshell -hidden -smp enable -kernel inet_dist_listen_min 35672 -kernel inet_dist_listen_max 35682 -run escript start -escript main rabbitmqctl_escript -extra /opt/bitnami/rabbitmq/escript/rabbitmq-diagnostics -q check_running
1001        9753  0.0  0.0   2380   576 ?        Ss   15:30   0:00      \_ erl_child_setup 1048576
```
=> the `rabbitmq-diagnostics` process is still there, even 36min after its start, and despite the 20s timeout

The explanation that I see:
```
I have no name!@rabbitmq-communication-1:/$ kill 9745; sleep 30; ps faux |grep 9745
1001       20010  0.0  0.0   6252   720 pts/0    S+   16:07   0:00  \_ grep 9745
1001        9745 99.3  0.0 2116920 57964 ?       Sl   15:30  36:41  \_ /opt/bitnami/erlang/lib/erlang/erts-13.2/bin/beam.smp -B -S 1:1 -- -root /opt/bitnami/erlang/lib/erlang -bindir /opt/bitnami/erlang/lib/erlang/erts-13.2/bin -progname erl -- -home /opt/bitnami/rabbitmq/.rabbitmq -- -boot start_clean -noshell -noinput -noshell -hidden -smp enable -kernel inet_dist_listen_min 35672 -kernel inet_dist_listen_max 35682 -run escript start -escript main rabbitmqctl_escript -extra /opt/bitnami/rabbitmq/escript/rabbitmq-diagnostics -q check_running
```
=> the stucked `rabbitmq-diagnostics` process doesn't respond to the TERM signal, and stays up

So, this PR is forcing a KILL signal after a few seconds more (because, obviously, this works and remove the process)