### PR TITLE
Set v2 as default for classic_queue + rmq 3.10.25

### DIFF
--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -31,7 +31,7 @@ global:
 image:
   registry: eu.gcr.io
   repository: bbc-registry/rabbitmq
-  tag: 3.10.20
+  tag: 3.10.25
   digest: ""
   ## set to true if you would like to see extra information on logs
   ## It turns BASH and/or NAMI debugging in the image

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -422,6 +422,8 @@ extraConfiguration: |-
   #default_vhost = {{ .Release.Namespace }}-vhost
   #disk_free_limit.absolute = 50MB
   disk_free_limit.absolute = 1GB
+  classic_queue.default_version = 2
+
 ## @param advancedConfiguration Configuration file content: advanced configuration
 ## Use this as additional configuration in classic config format (Erlang term configuration format)
 ##


### PR DESCRIPTION
To be tested (this is air-coding)