### PR TITLE
Exclude internode traffic from istio (DBRE-4975)

### DIFF
--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -724,6 +724,7 @@ podAnnotations: |
   sidecar.istio.io/proxyMemory: "{{ .Values.istio.proxyResources.requests.memory }}"
   sidecar.istio.io/proxyMemoryLimit: "{{ .Values.istio.proxyResources.limits.memory }}"
   # Traffic between RabbitMQ nodes should *not* be handled by istio to avoid network-partition incidents, cf: DBRE-4975
+  # NB: istio is mainly useful for web-console (via oauth-proxy) which is port 15672
   traffic.sidecar.istio.io/excludeOutboundPorts: "25672"
   traffic.sidecar.istio.io/excludeInboundPorts: "25672"
   {{- if .Values.datadog.enabled -}}

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -723,6 +723,9 @@ podAnnotations: |
   sidecar.istio.io/proxyCPULimit: "{{ .Values.istio.proxyResources.limits.cpu }}"
   sidecar.istio.io/proxyMemory: "{{ .Values.istio.proxyResources.requests.memory }}"
   sidecar.istio.io/proxyMemoryLimit: "{{ .Values.istio.proxyResources.limits.memory }}"
+  # Traffic between RabbitMQ nodes should *not* be handled by istio to avoid network-partition incidents, cf: DBRE-4975
+  traffic.sidecar.istio.io/excludeOutboundPorts: "25672"
+  traffic.sidecar.istio.io/excludeInboundPorts: "25672"
   {{- if .Values.datadog.enabled -}}
   {{- range $k, $v := .Values.datadog.annotations }}
   {{ $k }}: {{ tpl $v $ | quote }}


### PR DESCRIPTION
Goal of PR is explained as comment in the yaml.

Note: I confirmed that the port is the right one using docs on internet and using the webconsole on our of our clusters:
<img width="1019" height="468" alt="webconsole" src="https://github.com/user-attachments/assets/bda224a5-8df5-4d67-8a23-8e3f5bdfe500" />

Related to: DBRE-4975