### PR TITLE
[DBRE-RUN] Fix NetworkPolicy: Add istio metrics port

### DIFF
--- a/bitnami/rabbitmq/templates/networkpolicy.yaml
+++ b/bitnami/rabbitmq/templates/networkpolicy.yaml
@@ -62,7 +62,7 @@ spec:
         {{- if .Values.metrics.enabled }}
         - port: {{ .Values.containerPorts.metrics }}
         {{- end }}
-        {{- if .Values.istioMetrics.enabled }}
+        {{- if .Values.istio.metricsPortEnabled }}
         - port: {{ .Values.containerPorts.istioMetrics }}
         {{- end }}
       {{- if not .Values.networkPolicy.allowExternal }}

--- a/bitnami/rabbitmq/templates/networkpolicy.yaml
+++ b/bitnami/rabbitmq/templates/networkpolicy.yaml
@@ -62,6 +62,9 @@ spec:
         {{- if .Values.metrics.enabled }}
         - port: {{ .Values.containerPorts.metrics }}
         {{- end }}
+        {{- if .Values.istioMetrics.enabled }}
+        - port: {{ .Values.containerPorts.istioMetrics }}
+        {{- end }}
       {{- if not .Values.networkPolicy.allowExternal }}
       from:
         - podSelector:

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -1618,6 +1618,7 @@ istio:
     requests:
       cpu: 100m
       memory: 80Mi
+  metricsPortEnabled: true
 
 ## Istio configuration for OAuth2 Proxy
 manager:
@@ -1636,8 +1637,3 @@ manager:
 
 scheduling:
   nodepool: datastores   # enum: datastores, common
-
-
-## Istio Metrics
-istioMetrics:
-  enabled: true

--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -344,6 +344,7 @@ containerPorts:
   manager: 15672
   epmd: 4369
   metrics: 9419
+  istioMetrics: 15020
 ## @param initScripts Dictionary of init scripts. Evaluated as a template.
 ## Specify dictionary of scripts to be run at first boot
 ## Alternatively, you can put your scripts under the files/docker-entrypoint-initdb.d directory
@@ -1635,3 +1636,8 @@ manager:
 
 scheduling:
   nodepool: datastores   # enum: datastores, common
+
+
+## Istio Metrics
+istioMetrics:
+  enabled: true


### PR DESCRIPTION
Since NetworkPolicy are applied, istioMetrics are missed for rabbitmq.
This PR allow the port 15020 to authorize traffic on istioMetrics endpoint.
cf slack https://blablacar.slack.com/archives/G03EMFY19/p1786463094569319
