### PR TITLE
[DBRE-RUN] Fix istio metrics port

### DIFF
--- a/bitnami/rabbitmq/values.yaml
+++ b/bitnami/rabbitmq/values.yaml
@@ -344,7 +344,7 @@ containerPorts:
   manager: 15672
   epmd: 4369
   metrics: 9419
-  istioMetrics: 15020
+  istioMetrics: 15090
 ## @param initScripts Dictionary of init scripts. Evaluated as a template.
 ## Specify dictionary of scripts to be run at first boot
 ## Alternatively, you can put your scripts under the files/docker-entrypoint-initdb.d directory


### PR DESCRIPTION
The actual port open in istio-proxy is `15090`
cf https://blablacar.slack.com/archives/G03EMFY19/p1786544115836609?thread_ts=1786463094.569319&cid=G03EMFY19